### PR TITLE
Ensure URL paths don't start with multiple consecutive slashes

### DIFF
--- a/net/upnp/service.go
+++ b/net/upnp/service.go
@@ -213,8 +213,12 @@ func (self *Service) GetAbsoluteControlURL() (*url.URL, error) {
 	return self.getAbsoluteURL(self.ControlURL)
 }
 
-func (self *Service) GetAbsoluteEventSubURLL() (*url.URL, error) {
+func (self *Service) GetAbsoluteEventSubURL() (*url.URL, error) {
 	return self.getAbsoluteURL(self.EventSubURL)
+}
+
+func (self *Service) GetAbsoluteEventSubURLL() (*url.URL, error) {
+	return self.GetAbsoluteEventSubURL()
 }
 
 // GetActions returns all actions

--- a/net/upnp/util/url.go
+++ b/net/upnp/util/url.go
@@ -24,6 +24,7 @@ func GetAbsoluteURLFromBaseAndPath(base string, path string) (*url.URL, error) {
 
 	if err != nil || !url.IsAbs() {
 		base = strings.TrimSuffix(base, urlDelim)
+		path = strings.TrimPrefix(path, urlDelim)
 		path = strings.TrimSuffix(path, urlDelim)
 
 		urlStr := base + urlDelim + path

--- a/net/upnp/util/url_test.go
+++ b/net/upnp/util/url_test.go
@@ -5,6 +5,7 @@
 package util
 
 import (
+	"regexp"
 	"testing"
 )
 
@@ -99,11 +100,16 @@ func TestInvalidBaseAndValidPathURL(t *testing.T) {
 }
 
 func TestValidBaseAndPathURL(t *testing.T) {
+	re := regexp.MustCompile(`([^\:])[\/]{2,}`)
 	for _, base := range okBases() {
 		for _, path := range okPaths() {
-			_, err := GetAbsoluteURLFromBaseAndPath(base, path)
+			absUrl, err := GetAbsoluteURLFromBaseAndPath(base, path)
 			if err != nil {
 				t.Error(err)
+			}
+			expected := re.ReplaceAllString(base + "/" + path, `$1/`)
+			if expected != absUrl.String() {
+				t.Errorf(errorInvalidUrl, absUrl.String(), expected)
 			}
 		}
 	}


### PR DESCRIPTION
Ensure URL paths don't start with multiple consecutive slashes

Can cause some UPnP devices to return a HTTP 404 where otherwise valid

e.g. with some of the test data, this could produce:
```
http://yahoo.co.jp:80//foo/index.html
```

Where as this should be:
```
http://yahoo.co.jp:80/foo/index.html
```

It depends on the in-built server on the UPnP device as to whether it understands the former correctly. The latter should always be accepted.